### PR TITLE
Fix: calling selector on wrong class

### DIFF
--- a/APNumberPad.xcodeproj/project.pbxproj
+++ b/APNumberPad.xcodeproj/project.pbxproj
@@ -1,1204 +1,511 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>archiveVersion</key>
-	<string>1</string>
-	<key>classes</key>
-	<dict/>
-	<key>objectVersion</key>
-	<string>46</string>
-	<key>objects</key>
-	<dict>
-		<key>2ACD617819260EBD005E5DA5</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>2ACD618A19260EBD005E5DA5</string>
-				<string>2ACD61A319260EBD005E5DA5</string>
-				<string>2ACD618319260EBD005E5DA5</string>
-				<string>2ACD618219260EBD005E5DA5</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2ACD617919260EBD005E5DA5</key>
-		<dict>
-			<key>attributes</key>
-			<dict>
-				<key>CLASSPREFIX</key>
-				<string>AP</string>
-				<key>LastUpgradeCheck</key>
-				<string>0510</string>
-				<key>ORGANIZATIONNAME</key>
-				<string>Andrew Podkovyrin</string>
-				<key>TargetAttributes</key>
-				<dict>
-					<key>2ACD619B19260EBD005E5DA5</key>
-					<dict>
-						<key>TestTargetID</key>
-						<string>2ACD618019260EBD005E5DA5</string>
-					</dict>
-				</dict>
-			</dict>
-			<key>buildConfigurationList</key>
-			<string>2ACD617C19260EBD005E5DA5</string>
-			<key>compatibilityVersion</key>
-			<string>Xcode 3.2</string>
-			<key>developmentRegion</key>
-			<string>English</string>
-			<key>hasScannedForEncodings</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXProject</string>
-			<key>knownRegions</key>
-			<array>
-				<string>en</string>
-			</array>
-			<key>mainGroup</key>
-			<string>2ACD617819260EBD005E5DA5</string>
-			<key>productRefGroup</key>
-			<string>2ACD618219260EBD005E5DA5</string>
-			<key>projectDirPath</key>
-			<string></string>
-			<key>projectReferences</key>
-			<array/>
-			<key>projectRoot</key>
-			<string></string>
-			<key>targets</key>
-			<array>
-				<string>2ACD618019260EBD005E5DA5</string>
-				<string>2ACD619B19260EBD005E5DA5</string>
-			</array>
-		</dict>
-		<key>2ACD617C19260EBD005E5DA5</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>2ACD61AB19260EBD005E5DA5</string>
-				<string>2ACD61AC19260EBD005E5DA5</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>2ACD617D19260EBD005E5DA5</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>2ACD619119260EBD005E5DA5</string>
-				<string>B23467A31974A61800FE3F7A</string>
-				<string>B2DD031B197578030051DD71</string>
-				<string>B23467A11974A61800FE3F7A</string>
-				<string>B23467A21974A61800FE3F7A</string>
-				<string>2ACD620619261A19005E5DA5</string>
-				<string>2ACD619519260EBD005E5DA5</string>
-				<string>B23467A61974A66A00FE3F7A</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>2ACD617E19260EBD005E5DA5</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>2ACD618719260EBD005E5DA5</string>
-				<string>2ACD618919260EBD005E5DA5</string>
-				<string>2ACD618519260EBD005E5DA5</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>2ACD617F19260EBD005E5DA5</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>2ACD618F19260EBD005E5DA5</string>
-				<string>2ACD619719260EBD005E5DA5</string>
-				<string>2ACD620919261D53005E5DA5</string>
-			</array>
-			<key>isa</key>
-			<string>PBXResourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>2ACD618019260EBD005E5DA5</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>2ACD61AD19260EBD005E5DA5</string>
-			<key>buildPhases</key>
-			<array>
-				<string>2ACD617D19260EBD005E5DA5</string>
-				<string>2ACD617E19260EBD005E5DA5</string>
-				<string>2ACD617F19260EBD005E5DA5</string>
-				<string>DD1585B49C664D3A9648E68D</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>APNumberPad</string>
-			<key>productName</key>
-			<string>APNumberPad</string>
-			<key>productReference</key>
-			<string>2ACD618119260EBD005E5DA5</string>
-			<key>productType</key>
-			<string>com.apple.product-type.application</string>
-		</dict>
-		<key>2ACD618119260EBD005E5DA5</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.application</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>APNumberPad.app</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>2ACD618219260EBD005E5DA5</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>2ACD618119260EBD005E5DA5</string>
-				<string>2ACD619C19260EBD005E5DA5</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Products</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2ACD618319260EBD005E5DA5</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>2ACD618419260EBD005E5DA5</string>
-				<string>2ACD618619260EBD005E5DA5</string>
-				<string>2ACD618819260EBD005E5DA5</string>
-				<string>2ACD619D19260EBD005E5DA5</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Frameworks</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2ACD618419260EBD005E5DA5</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>Foundation.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/Foundation.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>2ACD618519260EBD005E5DA5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2ACD618419260EBD005E5DA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2ACD618619260EBD005E5DA5</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>CoreGraphics.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/CoreGraphics.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>2ACD618719260EBD005E5DA5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2ACD618619260EBD005E5DA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2ACD618819260EBD005E5DA5</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>UIKit.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/UIKit.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>2ACD618919260EBD005E5DA5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2ACD618819260EBD005E5DA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2ACD618A19260EBD005E5DA5</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>B234679A1974A61800FE3F7A</string>
-				<string>B23467991974A59B00FE3F7A</string>
-				<string>2ACD620819261D53005E5DA5</string>
-				<string>2ACD619319260EBD005E5DA5</string>
-				<string>2ACD619419260EBD005E5DA5</string>
-				<string>2ACD619619260EBD005E5DA5</string>
-				<string>2ACD618B19260EBD005E5DA5</string>
-				<string>2ACD620419261A19005E5DA5</string>
-				<string>2ACD620519261A19005E5DA5</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>APNumberPad</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2ACD618B19260EBD005E5DA5</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>2ACD618C19260EBD005E5DA5</string>
-				<string>2ACD618D19260EBD005E5DA5</string>
-				<string>2ACD619019260EBD005E5DA5</string>
-				<string>2ACD619219260EBD005E5DA5</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Supporting Files</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2ACD618C19260EBD005E5DA5</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>APNumberPad-Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2ACD618D19260EBD005E5DA5</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>2ACD618E19260EBD005E5DA5</string>
-			</array>
-			<key>isa</key>
-			<string>PBXVariantGroup</string>
-			<key>name</key>
-			<string>InfoPlist.strings</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2ACD618E19260EBD005E5DA5</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.strings</string>
-			<key>name</key>
-			<string>en</string>
-			<key>path</key>
-			<string>en.lproj/InfoPlist.strings</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2ACD618F19260EBD005E5DA5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2ACD618D19260EBD005E5DA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2ACD619019260EBD005E5DA5</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>main.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2ACD619119260EBD005E5DA5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2ACD619019260EBD005E5DA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2ACD619219260EBD005E5DA5</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>APNumberPad-Prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2ACD619319260EBD005E5DA5</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>APAppDelegate.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2ACD619419260EBD005E5DA5</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>APAppDelegate.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2ACD619519260EBD005E5DA5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2ACD619419260EBD005E5DA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2ACD619619260EBD005E5DA5</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>folder.assetcatalog</string>
-			<key>path</key>
-			<string>Images.xcassets</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2ACD619719260EBD005E5DA5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2ACD619619260EBD005E5DA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2ACD619819260EBD005E5DA5</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>2ACD61AA19260EBD005E5DA5</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>2ACD619919260EBD005E5DA5</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>2ACD619E19260EBD005E5DA5</string>
-				<string>2ACD61A019260EBD005E5DA5</string>
-				<string>2ACD619F19260EBD005E5DA5</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>2ACD619A19260EBD005E5DA5</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>2ACD61A819260EBD005E5DA5</string>
-			</array>
-			<key>isa</key>
-			<string>PBXResourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>2ACD619B19260EBD005E5DA5</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>2ACD61B019260EBD005E5DA5</string>
-			<key>buildPhases</key>
-			<array>
-				<string>2ACD619819260EBD005E5DA5</string>
-				<string>2ACD619919260EBD005E5DA5</string>
-				<string>2ACD619A19260EBD005E5DA5</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array>
-				<string>2ACD61A219260EBD005E5DA5</string>
-			</array>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>APNumberPadTests</string>
-			<key>productName</key>
-			<string>APNumberPadTests</string>
-			<key>productReference</key>
-			<string>2ACD619C19260EBD005E5DA5</string>
-			<key>productType</key>
-			<string>com.apple.product-type.bundle.unit-test</string>
-		</dict>
-		<key>2ACD619C19260EBD005E5DA5</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.cfbundle</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>APNumberPadTests.xctest</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>2ACD619D19260EBD005E5DA5</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>XCTest.framework</string>
-			<key>path</key>
-			<string>Library/Frameworks/XCTest.framework</string>
-			<key>sourceTree</key>
-			<string>DEVELOPER_DIR</string>
-		</dict>
-		<key>2ACD619E19260EBD005E5DA5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2ACD619D19260EBD005E5DA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2ACD619F19260EBD005E5DA5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2ACD618419260EBD005E5DA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2ACD61A019260EBD005E5DA5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2ACD618819260EBD005E5DA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2ACD61A119260EBD005E5DA5</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>2ACD617919260EBD005E5DA5</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>2ACD618019260EBD005E5DA5</string>
-			<key>remoteInfo</key>
-			<string>APNumberPad</string>
-		</dict>
-		<key>2ACD61A219260EBD005E5DA5</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>target</key>
-			<string>2ACD618019260EBD005E5DA5</string>
-			<key>targetProxy</key>
-			<string>2ACD61A119260EBD005E5DA5</string>
-		</dict>
-		<key>2ACD61A319260EBD005E5DA5</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>2ACD61A919260EBD005E5DA5</string>
-				<string>2ACD61A419260EBD005E5DA5</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>APNumberPadTests</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2ACD61A419260EBD005E5DA5</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>2ACD61A519260EBD005E5DA5</string>
-				<string>2ACD61A619260EBD005E5DA5</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Supporting Files</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2ACD61A519260EBD005E5DA5</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>APNumberPadTests-Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2ACD61A619260EBD005E5DA5</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>2ACD61A719260EBD005E5DA5</string>
-			</array>
-			<key>isa</key>
-			<string>PBXVariantGroup</string>
-			<key>name</key>
-			<string>InfoPlist.strings</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2ACD61A719260EBD005E5DA5</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.strings</string>
-			<key>name</key>
-			<string>en</string>
-			<key>path</key>
-			<string>en.lproj/InfoPlist.strings</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2ACD61A819260EBD005E5DA5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2ACD61A619260EBD005E5DA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2ACD61A919260EBD005E5DA5</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>APNumberPadTests.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2ACD61AA19260EBD005E5DA5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2ACD61A919260EBD005E5DA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2ACD61AB19260EBD005E5DA5</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES_ERROR</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES_AGGRESSIVE</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>6.0</string>
-				<key>ONLY_ACTIVE_ARCH</key>
-				<string>YES</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>2ACD61AC19260EBD005E5DA5</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>ENABLE_NS_ASSERTIONS</key>
-				<string>NO</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES_ERROR</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES_AGGRESSIVE</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>6.0</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>2ACD61AD19260EBD005E5DA5</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>2ACD61AE19260EBD005E5DA5</string>
-				<string>2ACD61AF19260EBD005E5DA5</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>2ACD61AE19260EBD005E5DA5</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ASSETCATALOG_COMPILER_APPICON_NAME</key>
-				<string>AppIcon</string>
-				<key>ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME</key>
-				<string>LaunchImage</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>APNumberPad/APNumberPad-Prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>APNumberPad/APNumberPad-Info.plist</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>app</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>2ACD61AF19260EBD005E5DA5</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ASSETCATALOG_COMPILER_APPICON_NAME</key>
-				<string>AppIcon</string>
-				<key>ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME</key>
-				<string>LaunchImage</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>APNumberPad/APNumberPad-Prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>APNumberPad/APNumberPad-Info.plist</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>app</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>2ACD61B019260EBD005E5DA5</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>2ACD61B119260EBD005E5DA5</string>
-				<string>2ACD61B219260EBD005E5DA5</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>2ACD61B119260EBD005E5DA5</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>BUNDLE_LOADER</key>
-				<string>$(BUILT_PRODUCTS_DIR)/APNumberPad.app/APNumberPad</string>
-				<key>FRAMEWORK_SEARCH_PATHS</key>
-				<array>
-					<string>$(SDKROOT)/Developer/Library/Frameworks</string>
-					<string>$(inherited)</string>
-					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
-				</array>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>APNumberPad/APNumberPad-Prefix.pch</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>INFOPLIST_FILE</key>
-				<string>APNumberPadTests/APNumberPadTests-Info.plist</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>TEST_HOST</key>
-				<string>$(BUNDLE_LOADER)</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>xctest</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>2ACD61B219260EBD005E5DA5</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>BUNDLE_LOADER</key>
-				<string>$(BUILT_PRODUCTS_DIR)/APNumberPad.app/APNumberPad</string>
-				<key>FRAMEWORK_SEARCH_PATHS</key>
-				<array>
-					<string>$(SDKROOT)/Developer/Library/Frameworks</string>
-					<string>$(inherited)</string>
-					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
-				</array>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>APNumberPad/APNumberPad-Prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>APNumberPadTests/APNumberPadTests-Info.plist</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>TEST_HOST</key>
-				<string>$(BUNDLE_LOADER)</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>xctest</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>2ACD620419261A19005E5DA5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>APNumberPadExampleViewController.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2ACD620519261A19005E5DA5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>APNumberPadExampleViewController.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2ACD620619261A19005E5DA5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2ACD620519261A19005E5DA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2ACD620819261D53005E5DA5</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.plug-in</string>
-			<key>path</key>
-			<string>APNumberPad.bundle</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2ACD620919261D53005E5DA5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2ACD620819261D53005E5DA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B23467991974A59B00FE3F7A</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>B23467A41974A66A00FE3F7A</string>
-				<string>B23467A51974A66A00FE3F7A</string>
-				<string>B2DD0319197578030051DD71</string>
-				<string>B2DD031A197578030051DD71</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>DemoStyles</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B234679A1974A61800FE3F7A</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>B234679B1974A61800FE3F7A</string>
-				<string>B234679C1974A61800FE3F7A</string>
-				<string>B234679D1974A61800FE3F7A</string>
-				<string>B234679E1974A61800FE3F7A</string>
-				<string>B234679F1974A61800FE3F7A</string>
-				<string>B23467A01974A61800FE3F7A</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>APNumberPad</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B234679B1974A61800FE3F7A</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>APNumberButton.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B234679C1974A61800FE3F7A</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>APNumberButton.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B234679D1974A61800FE3F7A</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>APNumberPad.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B234679E1974A61800FE3F7A</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>APNumberPad.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B234679F1974A61800FE3F7A</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>APNumberPadStyle.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B23467A01974A61800FE3F7A</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>APNumberPadStyle.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B23467A11974A61800FE3F7A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B234679C1974A61800FE3F7A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B23467A21974A61800FE3F7A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B234679E1974A61800FE3F7A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B23467A31974A61800FE3F7A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B23467A01974A61800FE3F7A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B23467A41974A66A00FE3F7A</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>APDarkPadStyle.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B23467A51974A66A00FE3F7A</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>APDarkPadStyle.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B23467A61974A66A00FE3F7A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B23467A51974A66A00FE3F7A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B2DD0319197578030051DD71</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>APBluePadStyle.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B2DD031A197578030051DD71</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>APBluePadStyle.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B2DD031B197578030051DD71</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B2DD031A197578030051DD71</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DD1585B49C664D3A9648E68D</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>Find unused imports</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>/bin/sh "/Users/podkovyrin/Library/Application Support/Developer/Shared/Xcode/Plug-ins/xcfui.xcplugin/Contents/Resources/fui_script.sh" "/Users/podkovyrin/Projects/APNumberPad"</string>
-			<key>showEnvVarsInLog</key>
-			<string>1</string>
-		</dict>
-	</dict>
-	<key>rootObject</key>
-	<string>2ACD617919260EBD005E5DA5</string>
-</dict>
-</plist>
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		2ACD618519260EBD005E5DA5 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2ACD618419260EBD005E5DA5 /* Foundation.framework */; };
+		2ACD618719260EBD005E5DA5 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2ACD618619260EBD005E5DA5 /* CoreGraphics.framework */; };
+		2ACD618919260EBD005E5DA5 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2ACD618819260EBD005E5DA5 /* UIKit.framework */; };
+		2ACD618F19260EBD005E5DA5 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 2ACD618D19260EBD005E5DA5 /* InfoPlist.strings */; };
+		2ACD619119260EBD005E5DA5 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 2ACD619019260EBD005E5DA5 /* main.m */; };
+		2ACD619519260EBD005E5DA5 /* APAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 2ACD619419260EBD005E5DA5 /* APAppDelegate.m */; };
+		2ACD619719260EBD005E5DA5 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2ACD619619260EBD005E5DA5 /* Images.xcassets */; };
+		2ACD619E19260EBD005E5DA5 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2ACD619D19260EBD005E5DA5 /* XCTest.framework */; };
+		2ACD619F19260EBD005E5DA5 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2ACD618419260EBD005E5DA5 /* Foundation.framework */; };
+		2ACD61A019260EBD005E5DA5 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2ACD618819260EBD005E5DA5 /* UIKit.framework */; };
+		2ACD61A819260EBD005E5DA5 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 2ACD61A619260EBD005E5DA5 /* InfoPlist.strings */; };
+		2ACD61AA19260EBD005E5DA5 /* APNumberPadTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2ACD61A919260EBD005E5DA5 /* APNumberPadTests.m */; };
+		2ACD620619261A19005E5DA5 /* APNumberPadExampleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2ACD620519261A19005E5DA5 /* APNumberPadExampleViewController.m */; };
+		2ACD620919261D53005E5DA5 /* APNumberPad.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 2ACD620819261D53005E5DA5 /* APNumberPad.bundle */; };
+		B23467A11974A61800FE3F7A /* APNumberButton.m in Sources */ = {isa = PBXBuildFile; fileRef = B234679C1974A61800FE3F7A /* APNumberButton.m */; };
+		B23467A21974A61800FE3F7A /* APNumberPad.m in Sources */ = {isa = PBXBuildFile; fileRef = B234679E1974A61800FE3F7A /* APNumberPad.m */; };
+		B23467A31974A61800FE3F7A /* APNumberPadStyle.m in Sources */ = {isa = PBXBuildFile; fileRef = B23467A01974A61800FE3F7A /* APNumberPadStyle.m */; };
+		B23467A61974A66A00FE3F7A /* APDarkPadStyle.m in Sources */ = {isa = PBXBuildFile; fileRef = B23467A51974A66A00FE3F7A /* APDarkPadStyle.m */; };
+		B2DD031B197578030051DD71 /* APBluePadStyle.m in Sources */ = {isa = PBXBuildFile; fileRef = B2DD031A197578030051DD71 /* APBluePadStyle.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		2ACD61A119260EBD005E5DA5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2ACD617919260EBD005E5DA5 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2ACD618019260EBD005E5DA5;
+			remoteInfo = APNumberPad;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		2ACD618119260EBD005E5DA5 /* APNumberPad.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = APNumberPad.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		2ACD618419260EBD005E5DA5 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		2ACD618619260EBD005E5DA5 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
+		2ACD618819260EBD005E5DA5 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
+		2ACD618C19260EBD005E5DA5 /* APNumberPad-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "APNumberPad-Info.plist"; sourceTree = "<group>"; };
+		2ACD618E19260EBD005E5DA5 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		2ACD619019260EBD005E5DA5 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		2ACD619219260EBD005E5DA5 /* APNumberPad-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "APNumberPad-Prefix.pch"; sourceTree = "<group>"; };
+		2ACD619319260EBD005E5DA5 /* APAppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = APAppDelegate.h; sourceTree = "<group>"; };
+		2ACD619419260EBD005E5DA5 /* APAppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = APAppDelegate.m; sourceTree = "<group>"; };
+		2ACD619619260EBD005E5DA5 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
+		2ACD619C19260EBD005E5DA5 /* APNumberPadTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = APNumberPadTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		2ACD619D19260EBD005E5DA5 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		2ACD61A519260EBD005E5DA5 /* APNumberPadTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "APNumberPadTests-Info.plist"; sourceTree = "<group>"; };
+		2ACD61A719260EBD005E5DA5 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		2ACD61A919260EBD005E5DA5 /* APNumberPadTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = APNumberPadTests.m; sourceTree = "<group>"; };
+		2ACD620419261A19005E5DA5 /* APNumberPadExampleViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APNumberPadExampleViewController.h; sourceTree = "<group>"; };
+		2ACD620519261A19005E5DA5 /* APNumberPadExampleViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = APNumberPadExampleViewController.m; sourceTree = "<group>"; };
+		2ACD620819261D53005E5DA5 /* APNumberPad.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = APNumberPad.bundle; sourceTree = "<group>"; };
+		B234679B1974A61800FE3F7A /* APNumberButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APNumberButton.h; sourceTree = "<group>"; };
+		B234679C1974A61800FE3F7A /* APNumberButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = APNumberButton.m; sourceTree = "<group>"; };
+		B234679D1974A61800FE3F7A /* APNumberPad.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APNumberPad.h; sourceTree = "<group>"; };
+		B234679E1974A61800FE3F7A /* APNumberPad.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = APNumberPad.m; sourceTree = "<group>"; };
+		B234679F1974A61800FE3F7A /* APNumberPadStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APNumberPadStyle.h; sourceTree = "<group>"; };
+		B23467A01974A61800FE3F7A /* APNumberPadStyle.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = APNumberPadStyle.m; sourceTree = "<group>"; };
+		B23467A41974A66A00FE3F7A /* APDarkPadStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APDarkPadStyle.h; sourceTree = "<group>"; };
+		B23467A51974A66A00FE3F7A /* APDarkPadStyle.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = APDarkPadStyle.m; sourceTree = "<group>"; };
+		B2DD0319197578030051DD71 /* APBluePadStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APBluePadStyle.h; sourceTree = "<group>"; };
+		B2DD031A197578030051DD71 /* APBluePadStyle.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = APBluePadStyle.m; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		2ACD617E19260EBD005E5DA5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2ACD618719260EBD005E5DA5 /* CoreGraphics.framework in Frameworks */,
+				2ACD618919260EBD005E5DA5 /* UIKit.framework in Frameworks */,
+				2ACD618519260EBD005E5DA5 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2ACD619919260EBD005E5DA5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2ACD619E19260EBD005E5DA5 /* XCTest.framework in Frameworks */,
+				2ACD61A019260EBD005E5DA5 /* UIKit.framework in Frameworks */,
+				2ACD619F19260EBD005E5DA5 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		2ACD617819260EBD005E5DA5 = {
+			isa = PBXGroup;
+			children = (
+				2ACD618A19260EBD005E5DA5 /* APNumberPad */,
+				2ACD61A319260EBD005E5DA5 /* APNumberPadTests */,
+				2ACD618319260EBD005E5DA5 /* Frameworks */,
+				2ACD618219260EBD005E5DA5 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		2ACD618219260EBD005E5DA5 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				2ACD618119260EBD005E5DA5 /* APNumberPad.app */,
+				2ACD619C19260EBD005E5DA5 /* APNumberPadTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		2ACD618319260EBD005E5DA5 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				2ACD618419260EBD005E5DA5 /* Foundation.framework */,
+				2ACD618619260EBD005E5DA5 /* CoreGraphics.framework */,
+				2ACD618819260EBD005E5DA5 /* UIKit.framework */,
+				2ACD619D19260EBD005E5DA5 /* XCTest.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		2ACD618A19260EBD005E5DA5 /* APNumberPad */ = {
+			isa = PBXGroup;
+			children = (
+				B234679A1974A61800FE3F7A /* APNumberPad */,
+				B23467991974A59B00FE3F7A /* DemoStyles */,
+				2ACD620819261D53005E5DA5 /* APNumberPad.bundle */,
+				2ACD619319260EBD005E5DA5 /* APAppDelegate.h */,
+				2ACD619419260EBD005E5DA5 /* APAppDelegate.m */,
+				2ACD619619260EBD005E5DA5 /* Images.xcassets */,
+				2ACD618B19260EBD005E5DA5 /* Supporting Files */,
+				2ACD620419261A19005E5DA5 /* APNumberPadExampleViewController.h */,
+				2ACD620519261A19005E5DA5 /* APNumberPadExampleViewController.m */,
+			);
+			path = APNumberPad;
+			sourceTree = "<group>";
+		};
+		2ACD618B19260EBD005E5DA5 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				2ACD618C19260EBD005E5DA5 /* APNumberPad-Info.plist */,
+				2ACD618D19260EBD005E5DA5 /* InfoPlist.strings */,
+				2ACD619019260EBD005E5DA5 /* main.m */,
+				2ACD619219260EBD005E5DA5 /* APNumberPad-Prefix.pch */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		2ACD61A319260EBD005E5DA5 /* APNumberPadTests */ = {
+			isa = PBXGroup;
+			children = (
+				2ACD61A919260EBD005E5DA5 /* APNumberPadTests.m */,
+				2ACD61A419260EBD005E5DA5 /* Supporting Files */,
+			);
+			path = APNumberPadTests;
+			sourceTree = "<group>";
+		};
+		2ACD61A419260EBD005E5DA5 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				2ACD61A519260EBD005E5DA5 /* APNumberPadTests-Info.plist */,
+				2ACD61A619260EBD005E5DA5 /* InfoPlist.strings */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		B23467991974A59B00FE3F7A /* DemoStyles */ = {
+			isa = PBXGroup;
+			children = (
+				B23467A41974A66A00FE3F7A /* APDarkPadStyle.h */,
+				B23467A51974A66A00FE3F7A /* APDarkPadStyle.m */,
+				B2DD0319197578030051DD71 /* APBluePadStyle.h */,
+				B2DD031A197578030051DD71 /* APBluePadStyle.m */,
+			);
+			path = DemoStyles;
+			sourceTree = "<group>";
+		};
+		B234679A1974A61800FE3F7A /* APNumberPad */ = {
+			isa = PBXGroup;
+			children = (
+				B234679B1974A61800FE3F7A /* APNumberButton.h */,
+				B234679C1974A61800FE3F7A /* APNumberButton.m */,
+				B234679D1974A61800FE3F7A /* APNumberPad.h */,
+				B234679E1974A61800FE3F7A /* APNumberPad.m */,
+				B234679F1974A61800FE3F7A /* APNumberPadStyle.h */,
+				B23467A01974A61800FE3F7A /* APNumberPadStyle.m */,
+			);
+			path = APNumberPad;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		2ACD618019260EBD005E5DA5 /* APNumberPad */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2ACD61AD19260EBD005E5DA5 /* Build configuration list for PBXNativeTarget "APNumberPad" */;
+			buildPhases = (
+				2ACD617D19260EBD005E5DA5 /* Sources */,
+				2ACD617E19260EBD005E5DA5 /* Frameworks */,
+				2ACD617F19260EBD005E5DA5 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = APNumberPad;
+			productName = APNumberPad;
+			productReference = 2ACD618119260EBD005E5DA5 /* APNumberPad.app */;
+			productType = "com.apple.product-type.application";
+		};
+		2ACD619B19260EBD005E5DA5 /* APNumberPadTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2ACD61B019260EBD005E5DA5 /* Build configuration list for PBXNativeTarget "APNumberPadTests" */;
+			buildPhases = (
+				2ACD619819260EBD005E5DA5 /* Sources */,
+				2ACD619919260EBD005E5DA5 /* Frameworks */,
+				2ACD619A19260EBD005E5DA5 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				2ACD61A219260EBD005E5DA5 /* PBXTargetDependency */,
+			);
+			name = APNumberPadTests;
+			productName = APNumberPadTests;
+			productReference = 2ACD619C19260EBD005E5DA5 /* APNumberPadTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		2ACD617919260EBD005E5DA5 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				CLASSPREFIX = AP;
+				LastUpgradeCheck = 0510;
+				ORGANIZATIONNAME = "Andrew Podkovyrin";
+				TargetAttributes = {
+					2ACD619B19260EBD005E5DA5 = {
+						TestTargetID = 2ACD618019260EBD005E5DA5;
+					};
+				};
+			};
+			buildConfigurationList = 2ACD617C19260EBD005E5DA5 /* Build configuration list for PBXProject "APNumberPad" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 2ACD617819260EBD005E5DA5;
+			productRefGroup = 2ACD618219260EBD005E5DA5 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				2ACD618019260EBD005E5DA5 /* APNumberPad */,
+				2ACD619B19260EBD005E5DA5 /* APNumberPadTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		2ACD617F19260EBD005E5DA5 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2ACD618F19260EBD005E5DA5 /* InfoPlist.strings in Resources */,
+				2ACD619719260EBD005E5DA5 /* Images.xcassets in Resources */,
+				2ACD620919261D53005E5DA5 /* APNumberPad.bundle in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2ACD619A19260EBD005E5DA5 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2ACD61A819260EBD005E5DA5 /* InfoPlist.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		2ACD617D19260EBD005E5DA5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2ACD619119260EBD005E5DA5 /* main.m in Sources */,
+				B23467A31974A61800FE3F7A /* APNumberPadStyle.m in Sources */,
+				B2DD031B197578030051DD71 /* APBluePadStyle.m in Sources */,
+				B23467A11974A61800FE3F7A /* APNumberButton.m in Sources */,
+				B23467A21974A61800FE3F7A /* APNumberPad.m in Sources */,
+				2ACD620619261A19005E5DA5 /* APNumberPadExampleViewController.m in Sources */,
+				2ACD619519260EBD005E5DA5 /* APAppDelegate.m in Sources */,
+				B23467A61974A66A00FE3F7A /* APDarkPadStyle.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2ACD619819260EBD005E5DA5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2ACD61AA19260EBD005E5DA5 /* APNumberPadTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		2ACD61A219260EBD005E5DA5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 2ACD618019260EBD005E5DA5 /* APNumberPad */;
+			targetProxy = 2ACD61A119260EBD005E5DA5 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		2ACD618D19260EBD005E5DA5 /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				2ACD618E19260EBD005E5DA5 /* en */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+		2ACD61A619260EBD005E5DA5 /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				2ACD61A719260EBD005E5DA5 /* en */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		2ACD61AB19260EBD005E5DA5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		2ACD61AC19260EBD005E5DA5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		2ACD61AE19260EBD005E5DA5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "APNumberPad/APNumberPad-Prefix.pch";
+				INFOPLIST_FILE = "APNumberPad/APNumberPad-Info.plist";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = app;
+			};
+			name = Debug;
+		};
+		2ACD61AF19260EBD005E5DA5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "APNumberPad/APNumberPad-Prefix.pch";
+				INFOPLIST_FILE = "APNumberPad/APNumberPad-Info.plist";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = app;
+			};
+			name = Release;
+		};
+		2ACD61B119260EBD005E5DA5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/APNumberPad.app/APNumberPad";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "APNumberPad/APNumberPad-Prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = "APNumberPadTests/APNumberPadTests-Info.plist";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUNDLE_LOADER)";
+				WRAPPER_EXTENSION = xctest;
+			};
+			name = Debug;
+		};
+		2ACD61B219260EBD005E5DA5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/APNumberPad.app/APNumberPad";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "APNumberPad/APNumberPad-Prefix.pch";
+				INFOPLIST_FILE = "APNumberPadTests/APNumberPadTests-Info.plist";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUNDLE_LOADER)";
+				WRAPPER_EXTENSION = xctest;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		2ACD617C19260EBD005E5DA5 /* Build configuration list for PBXProject "APNumberPad" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2ACD61AB19260EBD005E5DA5 /* Debug */,
+				2ACD61AC19260EBD005E5DA5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		2ACD61AD19260EBD005E5DA5 /* Build configuration list for PBXNativeTarget "APNumberPad" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2ACD61AE19260EBD005E5DA5 /* Debug */,
+				2ACD61AF19260EBD005E5DA5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		2ACD61B019260EBD005E5DA5 /* Build configuration list for PBXNativeTarget "APNumberPadTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2ACD61B119260EBD005E5DA5 /* Debug */,
+				2ACD61B219260EBD005E5DA5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 2ACD617919260EBD005E5DA5 /* Project object */;
+}

--- a/APNumberPad/APNumberPad/APNumberPad.m
+++ b/APNumberPad/APNumberPad/APNumberPad.m
@@ -346,13 +346,13 @@
             [self.textInput insertText:text];
         }
     } else if (_delegateFlags.delegateSupportsTextFieldShouldChangeCharactersInRange) {
-        NSRange selectedRange = [self.styleClass selectedRange:self.textInput];
+        NSRange selectedRange = [[self class] selectedRange:self.textInput];
         UITextField *textField = (UITextField *)self.textInput;
         if ([textField.delegate textField:textField shouldChangeCharactersInRange:selectedRange replacementString:text]) {
             [self.textInput insertText:text];
         }
     } else if (_delegateFlags.delegateSupportsTextViewShouldChangeTextInRange) {
-        NSRange selectedRange = [self.styleClass selectedRange:self.textInput];
+        NSRange selectedRange = [[self class] selectedRange:self.textInput];
         UITextView *textView = (UITextView *)self.textInput;
         if ([textView.delegate textView:textView shouldChangeTextInRange:selectedRange replacementText:text]) {
             [self.textInput insertText:text];
@@ -377,7 +377,7 @@
             [self.textInput deleteBackward];
         }
     } else if (_delegateFlags.delegateSupportsTextFieldShouldChangeCharactersInRange) {
-        NSRange selectedRange = [self.styleClass selectedRange:self.textInput];
+        NSRange selectedRange = [[self class] selectedRange:self.textInput];
         if (selectedRange.length == 0 && selectedRange.location > 0) {
             selectedRange.location--;
             selectedRange.length = 1;
@@ -387,7 +387,7 @@
             [self.textInput deleteBackward];
         }
     } else if (_delegateFlags.delegateSupportsTextViewShouldChangeTextInRange) {
-        NSRange selectedRange = [self.styleClass selectedRange:self.textInput];
+        NSRange selectedRange = [[self class] selectedRange:self.textInput];
         if (selectedRange.length == 0 && selectedRange.location > 0) {
             selectedRange.location--;
             selectedRange.length = 1;


### PR DESCRIPTION
Hello, 
Sorry I made a mistake. I was calling the "selectedRange" method on the styleClass which is totally wrong and the app would crash if you implement the UITextFieldDelegate. I've fixed the problem and also I've found a custom phase build that you use to check for unused imports.
