### PR TITLE
Added delegate method for highlighted image of clearButton

### DIFF
--- a/APNumberPad/APNumberPad/APNumberPad.m
+++ b/APNumberPad/APNumberPad/APNumberPad.m
@@ -97,6 +97,7 @@
         //
         self.clearButton = [self functionButton];
         [self.clearButton setImage:[self.styleClass clearFunctionButtonImage] forState:UIControlStateNormal];
+        [self.clearButton setImage:[self.styleClass clearFunctionButtonImageHighlighted] forState:UIControlStateHighlighted];
         [self.clearButton addTarget:self action:@selector(clearButtonAction) forControlEvents:UIControlEventTouchUpInside];
         
         UILongPressGestureRecognizer *longPressGestureRecognizer = [[UILongPressGestureRecognizer alloc]

--- a/APNumberPad/APNumberPad/APNumberPadDefaultStyle.m
+++ b/APNumberPad/APNumberPad/APNumberPadDefaultStyle.m
@@ -71,5 +71,8 @@ static inline UIColor * APNP_RGBa(int r, int g, int b, CGFloat alpha) {
     return [UIImage imageNamed:@"APNumberPad.bundle/images/apnumberpad_backspace_icon.png"];
 }
 
++(UIImage *)clearFunctionButtonImageHighlighted {
+    return [UIImage imageNamed:@"APNumberPad.bundle/images/apnumberpad_backspace_icon.png"];
+}
 
 @end

--- a/APNumberPad/APNumberPad/APNumberPadStyle.h
+++ b/APNumberPad/APNumberPad/APNumberPadStyle.h
@@ -23,5 +23,6 @@
 + (UIColor *)functionButtonHighlightedColor;
 + (UIColor *)functionButtonTextColor;
 + (UIImage *)clearFunctionButtonImage;
++ (UIImage *)clearFunctionButtonImageHighlighted;
 
 @end


### PR DESCRIPTION
I added a delegate method in order to set the image of the clear button in highlighted state. Feel free to merge if you think this is a useful addition to this library. I needed it in one of my projects which is why I created this fork.
If this method is not overriden it defaults to the image which is given for the normal button state.

Keep up the good work.

Cheers, David