### PR TITLE
Add manual hooks for becoming and losing first responder

### DIFF
--- a/APNumberPad/Classes/APNumberPad.h
+++ b/APNumberPad/Classes/APNumberPad.h
@@ -35,6 +35,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (strong, readonly, nonatomic) Class<APNumberPadStyle> styleClass;
 
+/**
+ * These methods must be called after the UIResponder using this class as its input view becomes or resigns the first responder.
+ * They will be called automatically if the UIResponder is an instance of UITextField or UITextView, but must be called manually
+ * if it is any other class.
+ */
+- (void)didBecomeActiveInputViewForResponder:(UIResponder<UIKeyInput> *)responder;
+- (void)didResignInputViewForResponder;
+
 @end
 
 ///

--- a/APNumberPad/Classes/APNumberPad.m
+++ b/APNumberPad/Classes/APNumberPad.m
@@ -203,7 +203,18 @@
     }
 
     UIResponder<UIKeyInput> *textInput = notification.object;
+    [self didBecomeActiveInputViewForResponder:textInput];
+}
 
+- (void)textDidEndEditing:(NSNotification *)notification {
+    [self didResignInputViewForResponder];
+}
+
+- (void)didResignInputViewForResponder {
+    self.textInput = nil;
+}
+
+- (void)didBecomeActiveInputViewForResponder:(UIResponder<UIKeyInput> *)textInput {
     if (textInput.inputView && self == textInput.inputView) {
         self.textInput = textInput;
 
@@ -227,10 +238,6 @@
             }
         }
     }
-}
-
-- (void)textDidEndEditing:(NSNotification *)notification {
-    self.textInput = nil;
 }
 
 #pragma mark - UIResponder


### PR DESCRIPTION
Minor issue discovered using 1.2.4 in wild: the textInput local property is not set if the UIResponder the numberPad is attached to is not a UITextField or UITextView, since custom classes don't issue the NSNotifications expected.

This exposes the "did become" and "did resign" hooks via the public API, so that developers using this class can call them manually if their input is a custom UIControl.