### PR TITLE
Allow custom definition of the safe area color

### DIFF
--- a/APNumberPad/Classes/APNumberPad.m
+++ b/APNumberPad/Classes/APNumberPad.m
@@ -21,6 +21,11 @@
 }
 
 /**
+ * Plain UIView used to block out the safe area
+ */
+@property (strong, readwrite, nonatomic) UIView *safeAreaCover;
+
+/**
  *  Array of APNumberButton
  */
 @property (copy, readwrite, nonatomic) NSArray *numberButtons;
@@ -85,6 +90,10 @@
         }
         self.numberButtons = numberButtons;
 
+        self.safeAreaCover = [[UIView alloc] initWithFrame:CGRectZero];
+        self.safeAreaCover.backgroundColor = [self.styleClass safeAreaSpaceColor];
+        [self addSubview:self.safeAreaCover];
+
         // Function button
         //
         self.leftButton = [self functionButton];
@@ -119,10 +128,13 @@
 
     CGFloat boundsWidth = CGRectGetWidth(self.bounds);
     CGFloat boundsHeight = CGRectGetHeight(self.bounds);
-    
+    CGFloat safeAreaHeight = 0;
+
     if (@available(iOS 11.0, *)) {
-        boundsHeight -= self.safeAreaInsets.bottom;
+        safeAreaHeight = self.safeAreaInsets.bottom;
     }
+
+    boundsHeight -= safeAreaHeight;
 
     int rows = 4;
     int sections = 3;
@@ -171,6 +183,9 @@
     //
     left += buttonSize.width + sep;
     self.clearButton.frame = CGRectMake(left, top, buttonSize.width, buttonSize.height);
+
+    // Safe area cover
+    self.safeAreaCover.frame = CGRectMake(0, top + buttonSize.height + sep, boundsWidth, safeAreaHeight);
 }
 
 #pragma mark - Notifications

--- a/APNumberPad/Classes/APNumberPadDefaultStyle.m
+++ b/APNumberPad/Classes/APNumberPadDefaultStyle.m
@@ -32,6 +32,10 @@ static inline UIColor *APNP_RGBa(int r, int g, int b, CGFloat alpha) {
     return APNP_RGBa(183, 186, 191, 1.0);
 }
 
++ (UIColor *)safeAreaSpaceColor {
+    return [UIColor clearColor];
+}
+
 #pragma mark - Number button
 
 + (UIFont *)numberButtonFont {

--- a/APNumberPad/Classes/APNumberPadStyle.h
+++ b/APNumberPad/Classes/APNumberPadStyle.h
@@ -14,6 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (CGRect)numberPadFrame;
 + (CGFloat)separator;
 + (UIColor *)numberPadBackgroundColor;
++ (UIColor *)safeAreaSpaceColor;
 
 + (UIFont *)numberButtonFont;
 + (UIColor *)numberButtonBackgroundColor;


### PR DESCRIPTION
Creates a style method that allows the user of the class to define a custom color with which to cover the bottom safe area on devices such as the iPad Pro or iPhone X.