### PR TITLE
Use framework only, no separate resource bundle anymore

### DIFF
--- a/APNumberPad.podspec
+++ b/APNumberPad.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'APNumberPad'
-  s.version          = '1.3.3'
+  s.version          = '1.3.4'
   s.summary          = 'Full clone of iOS number keyboard with customizable function button'
 
   s.description      = <<-DESC
@@ -16,13 +16,12 @@ Also APNumberPad provides customizable left-function button.
   s.source           = { :git => 'https://github.com/podkovyrin/APNumberPad.git', :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/podkovyr'
 
-  s.ios.deployment_target = '9.0'
+  # s.ios.deployment_target = '9.0'
+  s.ios.deployment_target = '15.0'
 
-  s.source_files = 'APNumberPad/Sources/*.{h,m}'
-  s.public_header_files = 'APNumberPad/Sources/*.h'
-  s.resource_bundles = {
-    'APNumberPad' => ['APNumberPad/Assets/*.png']
-  }
+  s.source_files = 'APNumberPad/**/*.{h,m}'
+  s.public_header_files = 'APNumberPad/*.h'
+  s.resources = 'APNumberPad/Assets/*.png'
 
   s.frameworks = 'UIKit'
 end

--- a/APNumberPad/Sources/NSBundle+APNumberPad.m
+++ b/APNumberPad/Sources/NSBundle+APNumberPad.m
@@ -8,6 +8,7 @@
 //  Category credits to Chris Dzombak https://github.com/NYTimes/NYTPhotoViewer
 
 #import "NSBundle+APNumberPad.h"
+#import "APNumberPad.h"
 
 @implementation NSBundle (APNumberPad)
 
@@ -18,8 +19,7 @@
     static NSBundle *resourceBundle = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        NSString *resourceBundlePath = [[NSBundle bundleForClass:NSClassFromString(@"APNumberPad")] pathForResource:@"APNumberPad" ofType:@"bundle"];
-        resourceBundle = [self bundleWithPath:resourceBundlePath];
+        resourceBundle = [NSBundle bundleForClass:[APNumberPad class]];
     });
 
     return resourceBundle;


### PR DESCRIPTION
This fixes issue #35 

How?
Previously, the three icons went into an own resource bundle. This change does avoid the extra bundle and includes the images directly into the APNumberPad framework. 

Why?
Since Xcode 14, after a pod install the "Team" setting of the resource bundle went missing. 

Note: 
- tested only with iOS target minimum of iOS 15
- tested only with cocoapods
- no need anymore to keep the code in a NSBundle category. Refactoring advised. 